### PR TITLE
🐛  Check source branch name availability before use

### DIFF
--- a/src/danger.ts
+++ b/src/danger.ts
@@ -291,7 +291,7 @@ const branchName: Checker = (danger, options) => {
   const sourceBranchName =
     danger.gitlab?.mr?.source_branch ?? danger.github?.pr?.head?.ref
   const [branchMatched, type, issueNumber] =
-    sourceBranchName.match(/([a-z]+)\/([0-9]+)(.*)/) ?? []
+    sourceBranchName?.match(/([a-z]+)\/([0-9]+)(.*)/) ?? []
   options.branchTrackerId = issueNumber
   if (!branchMatched) {
     return [{ branchName: sourceBranchName, type: OffenseType.BRANCH_FORMAT }]


### PR DESCRIPTION
I tried to run `danger local` but it fails because of missing branch name. This little fix handles the case when we run rules neither at gitlab or github environment.