### PR TITLE
🔥 Remove require-await

### DIFF
--- a/eslint.md
+++ b/eslint.md
@@ -69,10 +69,6 @@ While more reasonable in limiting the rule, it still discourages from using type
 
 There is (almost) no use for awaiting returned value, except for in try block, where you want to handle rejected state. We allow only in try block. Allowing or even requiring it everywhere results in people throwing async everywhere and we don't want that.
 
-#### Added `require-await`
-
-There is (almost) no reason to use `async` when there is no `await`.
-
 ### Naming conventions
 
 #### Modified `new-cap`

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -55,7 +55,6 @@ export = {
     '@typescript-eslint/explicit-function-return-type': 0,
     '@typescript-eslint/explicit-module-boundary-types': 0,
     '@typescript-eslint/return-await': [2, 'in-try-catch'],
-    'require-await': 2,
 
     // naming conventions
     'new-cap': [2, { properties: false }],


### PR DESCRIPTION
Based on our meeting discussion, I am disabling the `require-await` rule.

Reason: Throws unnecessary errors when prototyping partial implementation or mocking replacement functions e.g. with `jest.spyOn.mockImplementation`.

Looks like it was added by us in the early days, so I have just removed the rule from overrides.

I have tested on node-template via eslint config dump that its not present in the final rule set `npx eslint --print-config .eslintrc.js`

Related: #0