### PR TITLE
✨ Reduce severity of @typescript-eslint/prefer-nullish-coalescing

### DIFF
--- a/eslint.md
+++ b/eslint.md
@@ -82,3 +82,5 @@ Reduced severity to warning for the following rules: `sonarjs/cognitive-complexi
 Reduced severity to warning for `@typescript-eslint/no-use-before-define`, because while this recommendation generally makes sense, most of critical issues are reported by TS compiler. The reports on usage in types themselves are usually not impactful.
 
 Reduced severity to warning for `sonarjs/no-identical-functions`, since it sometimes happens, that several trivial functions are reported as repeated, even though refactoring does not improve the code quality.
+
+Reduced severity to warning for @typescript-eslint/prefer-nullish-coalescing as logical OR operation can be desirable and is not equivalent with nullish coalescing.

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -50,6 +50,8 @@ export = {
     '@typescript-eslint/no-floating-promises': [2, { ignoreVoid: true }],
     'no-void': [2, { allowAsStatement: true }],
 
+    // Less strictness over ??
+    '@typescript-eslint/prefer-nullish-coalescing': 1,
     // consistent code
     '@typescript-eslint/promise-function-async': 0,
     '@typescript-eslint/explicit-function-return-type': 0,


### PR DESCRIPTION
⬆️ Run automatic npm audit fix

The @typescript-eslint/prefer-nullish-coalescing is often too strict, trying to enforce nullish operator even in situation where simple logical OR is the simplest and correct solution.