### PR TITLE
🔥 Remove strict boolean expressions

### DIFF
--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -40,7 +40,6 @@ export = {
     '@typescript-eslint/member-delimiter-style': 0,
 
     // error prevention
-    '@typescript-eslint/strict-boolean-expressions': 1,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/restrict-template-expressions': [
       2,


### PR DESCRIPTION
# Remove strict-boolean-expressions
This PR removes `strict-boolean-expressions` as it comes with a couple of drawbacks that do not improve the quality of the code. 

## Examples

```typescript
if (someArray.length) {} // warning, even though NaN and 0 are not possible here

if (!someString) {} // warning, "" can be an issue, but "" is still by our opinion invalid string

if (nullableBoolean) {} // warning, we tend to use nullable boolean as default false and it's okay to use it in conditions this way

if (nullableObject) {} // warning, nullable objects are safe in coditions we want to perform these checks without typecast

if (someArray.length && otherCondition) {} // warning, needs at least:
if (Boolean(someArray.length) && otherCondition) {} // conflicts with rule no-extra-boolean-cast

if (items?.length) {} // warning needs:
if (items.cargos != null && items.cargos.length > 0) // decreasing readability, no improvement to the quality of security
```

## Autofix

The autofix `nullable == null` is not a part of our Ackee codebase a lot since we prefer to use strict equality.