### PR TITLE
➕ Add eslint plugin security

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,15 +39,16 @@
     "danger": "^11.2.0",
     "eslint": "^8.29.0",
     "eslint-config-standard-with-typescript": "^23.0.0",
+    "eslint-formatter-codeframe": "^7.32.1",
     "eslint-plugin-import": "^2.26.0",
     "eslint-plugin-n": "^15.6.0",
     "eslint-plugin-promise": "^6.1.1",
     "eslint-plugin-sonarjs": "^0.17.0",
-    "prettier": "^2.8.1",
-    "eslint-formatter-codeframe": "^7.32.1"
+    "prettier": "^2.8.1"
   },
   "devDependencies": {
     "@types/jest": "^29.2.4",
+    "eslint-plugin-security": "^2.1.0",
     "husky": "^8.0.2",
     "jest": "^29.3.1",
     "lint-staged": "^13.1.0",

--- a/src/eslint.ts
+++ b/src/eslint.ts
@@ -7,6 +7,7 @@ export = {
     'plugin:@typescript-eslint/recommended',
     'standard-with-typescript',
     'plugin:sonarjs/recommended',
+    'plugin:security/recommended-legacy',
   ],
   parserOptions: {
     project: './tsconfig.json',
@@ -39,6 +40,7 @@ export = {
     '@typescript-eslint/no-extra-semi': 0,
     '@typescript-eslint/member-delimiter-style': 0,
     // error prevention
+    'security/detect-object-injection': 0,
     '@typescript-eslint/no-explicit-any': 0,
     '@typescript-eslint/strict-boolean-expressions': 0,
     '@typescript-eslint/restrict-template-expressions': [
@@ -73,7 +75,6 @@ export = {
         checkSpreads: true,
       },
     ],
-
     // naming conventions
     'new-cap': 0,
 


### PR DESCRIPTION
## Proposed changes
- Adds well known extension [eslint-plugin-security](https://github.com/eslint-community/eslint-plugin-security/tree/main) 
   - Improves developer knowledge about security issues within the code
   - Recommendation by [nodebestpractices](https://github.com/goldbergyoni/nodebestpractices?tab=readme-ov-file#-61-embrace-linter-security-rules)
   - Tested on active projects with good results
- Disables [detect-object-injection](https://github.com/eslint-community/eslint-plugin-security/blob/main/docs/rules/detect-object-injection.md) rule since it complains even about basic code constructs like array index access, can be enabled project wise. 