### PR TITLE
💚 Remove npm publish provenance flag

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,4 +20,4 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
       - run: npm run build
-      - run: npm publish --provenance
+      - run: npm publish


### PR DESCRIPTION
Package is publish with provenance by default when having trusted publishing

REDMINE-100208
